### PR TITLE
License update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Slade Rice Watkins
+Copyright (c) 2022-present Slade Rice Watkins and contributors
 Copyright (c) 2020-present Jared White and Bridgetown contributors
 Copyright (c) 2008-2020 Tom Preston-Werner and Jekyll contributors
 

--- a/src/legal/website-licenses/mit/index.md
+++ b/src/legal/website-licenses/mit/index.md
@@ -6,7 +6,7 @@ title: Website Licenses - MIT License
 ```
 MIT License
 
-Copyright (c) 2022 Slade Rice Watkins
+Copyright (c) 2022-present Slade Rice Watkins and contributors
 Copyright (c) 2020-present Jared White and Bridgetown contributors
 Copyright (c) 2008-2020 Tom Preston-Werner and Jekyll contributors
 


### PR DESCRIPTION
This updates the license to futureproof for 2023 and beyond, as well as credit contributors past and present within.

Signed-off-by: Slade Watkins <srw@sladewatkins.net>