### PR TITLE
OneCMS 7.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ The tweaks and changes from Bridgetown 1.1.0 include:
 ## Licensing
 I've open sourced OneCMS 7+ under the [MIT License](https://github.com/sladewatkins/website/blob/master/LICENSE). (Do note that my blog and site text are licensed under the [CC-BY-SA-4.0 license](https://github.com/sladewatkins/website/blob/master/LICENSE-CC-BY-SA-4.0).)
 
+## Maintaining the codebase
+The two most recent point releases of OneCMS are maintained, with the oldest supported release getting vital security updates **only**.
+
+Currently maintained releases:
+- [7.1.y (current)](https://github.com/sladewatkins/website/tree/master)
+- [7.0.y](https://github.com/sladewatkins/website/tree/version-7.0.y)
+
+Versions prior to the above are End-Of-Life and are no longer supported.
+
 ## About this site
 I'm building this site to be database-free, no SQL of any kind to be found. I hate working with SQL (and maintaining those servers) and this is my attempt to stop doing so.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ TL:DR: this simply requires a webserver, as well as support for Ruby and [Bridge
 The [``gh-pages``](https://github.com/sladewatkins/website/tree/gh-pages) tree within this repository contains the production assets served to the public on [sladewatkins.com](https://www.sladewatkins.com).
 
 ### The [``staging``](https://github.com/sladewatkins/website/tree/staging) branch
-The [``staging``](https://github.com/sladewatkins/website/tree/staging) branch is special - that's where all commits set to roll out to production ("master" branch) need to sit and be tested by Slade's Continous Integration (CI) system + a few of his physical systems. This is to ensure no issues are found and things keep going smoothly.
+The [``staging``](https://github.com/sladewatkins/website/tree/staging) branch is special - that's where all commits set to roll out to the latest OneCMS release and production website ("master" branch) need to sit and be tested by Slade's Continous Integration (CI) system + a few of his physical systems. This is to ensure no issues are found and things keep going smoothly.
 
 ## Find an issue?
 If you find an issue, you might be able to patch it up yourself! Check out [the guide](https://www.sladewatkins.com/docs/website/) to see how you can help. When you've put together your changes, submit them as a [pull request](https://github.com/sladewatkins/website/pulls) directed to the [``staging``](https://github.com/sladewatkins/website/tree/staging) branch! I'll take a look at it and might merge it in. (Note: all PRs sent to the ``master`` branch won't be considered. Commits must target ``staging``, see [the documentation here](https://www.sladewatkins.com/docs/website/how-staging-works/) for more details.)

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ The tweaks and changes from Bridgetown 1.1.0 include:
 ## Licensing
 I've open sourced OneCMS 7+ under the [MIT License](https://github.com/sladewatkins/website/blob/master/LICENSE). (Do note that my blog and site text are licensed under the [CC-BY-SA-4.0 license](https://github.com/sladewatkins/website/blob/master/LICENSE-CC-BY-SA-4.0).)
 
-## Production assets
-The [``gh-pages``](https://github.com/sladewatkins/website/tree/gh-pages) tree within this repository contains the production assets served to the public on [sladewatkins.com](https://www.sladewatkins.com).
-
 ## About this site
 I'm building this site to be database-free, no SQL of any kind to be found. I hate working with SQL (and maintaining those servers) and this is my attempt to stop doing so.
 
 TL:DR: this simply requires a webserver, as well as support for Ruby and [Bridgetown](https://www.bridgetownrb.com/) (if hosting locally for development), and it DOESN'T REQUIRE SQL/Database servers of any kind. Yay!
 
-## The [``staging``](https://github.com/sladewatkins/website/tree/staging) branch
+### Production assets
+The [``gh-pages``](https://github.com/sladewatkins/website/tree/gh-pages) tree within this repository contains the production assets served to the public on [sladewatkins.com](https://www.sladewatkins.com).
+
+### The [``staging``](https://github.com/sladewatkins/website/tree/staging) branch
 The [``staging``](https://github.com/sladewatkins/website/tree/staging) branch is special - that's where all commits set to roll out to production ("master" branch) need to sit and be tested by Slade's Continous Integration (CI) system + a few of his physical systems. This is to ensure no issues are found and things keep going smoothly.
 
 ## Find an issue?

--- a/src/docs/website/how-staging-works/index.md
+++ b/src/docs/website/how-staging-works/index.md
@@ -5,6 +5,6 @@ title: Website - How staging works
 
 Patches, pull requests, and anything from anyone are pulled into the ``staging`` branch (or "tree"). That tree is the destination for all in-progress work.
 
-You can think of this as the destination for commits that are ready to get pushed to production, but on their own, are too insignificant to be pushed on their own. Once enough commits pile up in staging*, then (and only then) will I pull them up into the ``master`` tree. ``staging`` resets once all commits are pulled up into ``master``, as both trees become equal, which allows me to pick back up from square one.
+You can think of this as the destination for commits that are ready to get pushed to production (the latest version of OneCMS), but on their own, are too insignificant to be pushed on their own. Once enough commits pile up in staging*, then (and only then) will I pull them up into the ``master`` tree. ``staging`` resets once all commits are pulled up into ``master``, as both trees become equal, which allows me to pick back up from square one.
 
 *Though, at the very least, I try to clear the ``staging`` tree at least once daily. That way things aren't getting _too_ clogged up.

--- a/src/sitemap/index.md
+++ b/src/sitemap/index.md
@@ -27,3 +27,5 @@ This list is unsorted.
 - [Blo(n)g(er) RSS](https://www.sladewatkins.com/feed.xml)
 - [Sitemap XML](https://www.sladewatkins.com/sitemap.xml)
 - [WebFinger](https://www.sladewatkins.com/.well-known/webfinger)
+- [NodeInfo](https://www.sladewatkins.com/.well-known/nodeinfo)
+- [Host-Meta](https://www.sladewatkins.com/.well-known/host-meta)


### PR DESCRIPTION
- expose WebFinger to public view
- update information in README and other documentation

Latter changes to README and documentation will be backported to 7.0.y.