### PR TITLE
OneCMS 7.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ gem "bridgetown", "~> 1.2.0"
 # (you can optionally limit this to the "development" group)
 gem "puma", "~> 6.0"
 
-gem "bridgetown-feed", "~> 3.0", :group => :bridgetown_plugins
-
 gem "roda-turbo", "~> 1.0"
 
 gem "bridgetown-sitemap", "~> 2.0", :group => :bridgetown_plugins
+
+gem "bridgetown-feed", "~> 3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ gem "bridgetown", "~> 1.2.0"
 # (you can optionally limit this to the "development" group)
 gem "puma", "~> 6.0"
 
+gem "bridgetown-feed", "~> 2.1", :group => :bridgetown_plugins
+
 gem "roda-turbo", "~> 1.0"
 
 gem "bridgetown-sitemap", "~> 2.0", :group => :bridgetown_plugins
-
-gem "bridgetown-feed", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,8 @@ GEM
       tilt (~> 2.0)
       webrick (~> 1.7)
       zeitwerk (~> 2.5)
-    bridgetown-feed (3.0.0)
-      bridgetown (>= 1.2.0.beta2, < 2.0)
+    bridgetown-feed (2.1.0)
+      bridgetown (>= 1.0.0.alpha5, < 2.0)
     bridgetown-paginate (1.2.0)
       bridgetown-core (= 1.2.0)
     bridgetown-sitemap (2.0.0)
@@ -123,7 +123,7 @@ PLATFORMS
 
 DEPENDENCIES
   bridgetown (~> 1.2.0)
-  bridgetown-feed (~> 3.0)
+  bridgetown-feed (~> 2.1)
   bridgetown-sitemap (~> 2.0)
   puma (~> 6.0)
   roda-turbo (~> 1.0)

--- a/frontend/javascript/index.js
+++ b/frontend/javascript/index.js
@@ -13,7 +13,7 @@ import { Application } from "@hotwired/stimulus"
 // Import all JavaScript & CSS files from src/_components
 import components from "bridgetownComponents/**/*.{js,jsx,js.rb,css}"
 
-console.info("OneCMS 7.2.1 loaded!")
+console.info("OneCMS 7.2.2 loaded!")
 
 window.Stimulus = Application.start()
 

--- a/src/_data/site_metadata.yml
+++ b/src/_data/site_metadata.yml
@@ -9,5 +9,5 @@ tagline: Web Developer, Content Creator
 email: slade@sladewatkins.com
 roothttp: https://www.sladewatkins.com
 description: Slade is a web developer and content creator who makes stuff from time-to-time.
-generator: OneCMS 7.2.1
-builddate: February 1, 2023
+generator: OneCMS 7.2.2
+builddate: February 2, 2023


### PR DESCRIPTION
What's new:
- This release fixes a bug introduced by updating the bridgetown-feed dependency to 3.0.0.
- It includes all other fixes from OneCMS 7.2.1.

Fixes: https://github.com/sladewatkins/website/commit/fa9d69c9310ed77526f4e2d6ecdbbff75d73d561 (OneCMS 7.2.1)
Fixes: https://github.com/sladewatkins/website/commit/5f9ec41cdc9ccb00275753cee0446cfe2ce4c67c (gems: update bridgetown-feed to 3.0.0)
Cc: dependabot[bot] <support@github.com>